### PR TITLE
Add back non-push version of function XrdAccAuthorizeObject

### DIFF
--- a/src/XrdAccSciTokens.cc
+++ b/src/XrdAccSciTokens.cc
@@ -24,11 +24,6 @@
 // The status-quo to retrieve the default object is to copy/paste the
 // linker definition and invoke directly.
 XrdVERSIONINFO(XrdAccAuthorizeObject, XrdAccSciTokens);
-extern XrdAccAuthorize *XrdAccDefaultAuthorizeObject(XrdSysLogger   *lp,
-                                                     const char     *cfn,
-                                                     const char     *parm,
-                                                     XrdVersionInfo &myVer);
-
 
 namespace {
 

--- a/src/XrdAccSciTokens.cc
+++ b/src/XrdAccSciTokens.cc
@@ -23,6 +23,7 @@
 
 // The status-quo to retrieve the default object is to copy/paste the
 // linker definition and invoke directly.
+XrdVERSIONINFO(XrdAccAuthorizeObject, XrdAccSciTokens);
 extern XrdAccAuthorize *XrdAccDefaultAuthorizeObject(XrdSysLogger   *lp,
                                                      const char     *cfn,
                                                      const char     *parm,
@@ -1003,6 +1004,12 @@ XrdAccAuthorize *XrdAccAuthorizeObjectAdd(XrdSysLogger *lp,
     return (accSciTokens ? accSciTokens : nullptr);
 }
 
+XrdAccAuthorize *XrdAccAuthorizeObject(XrdSysLogger *lp,
+                                       const char   *cfn,
+                                       const char   *parm)
+{
+    return XrdAccAuthorizeObjectAdd(lp, cfn, parm, 0);
+}
 
 
 }


### PR DESCRIPTION
Want to make sure backwards compatibility continues.