### PR TITLE
Remove error when there are no issuers.

### DIFF
--- a/src/XrdAccSciTokens.cc
+++ b/src/XrdAccSciTokens.cc
@@ -905,7 +905,6 @@ private:
 
         if (issuers.empty()) {
             m_log.Emsg("Reconfig", "No issuers configured.");
-            return false;
         }
 
         pthread_rwlock_wrlock(&m_config_lock);


### PR DESCRIPTION
No issuers configured should not be an error, but it will also
not allow any tokens to authenticate.
Ticket: https://opensciencegrid.atlassian.net/browse/SOFTWARE-4223