### PR TITLE
Rename XrdAccAuthorizeObjAdd function to match xrootd's expectations

### DIFF
--- a/src/XrdAccSciTokens.cc
+++ b/src/XrdAccSciTokens.cc
@@ -966,7 +966,7 @@ std::string      cfgSciTokens;
 
 extern "C" {
 
-XrdAccAuthorize *XrdAccAuthorizeObjectAdd(XrdSysLogger *lp,
+XrdAccAuthorize *XrdAccAuthorizeObjAdd(XrdSysLogger *lp,
                                           const char   *cfn,
                                           const char   *parm,
                                        XrdAccAuthorize *accP)


### PR DESCRIPTION
Related to https://github.com/xrootd/xrootd/issues/1353